### PR TITLE
fix: apply lf line endings to .jsx and .json files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf


### PR DESCRIPTION
I already tried to fix it, but forget that we use mostly .jsx files. Now it's fixed. As well, as .json files